### PR TITLE
Small fixes

### DIFF
--- a/app/_components/singlePost.tsx
+++ b/app/_components/singlePost.tsx
@@ -5,6 +5,7 @@ import { Post } from '@prisma/client';
 import { prisma } from '@/utils/prisma';
 import { reportPost } from '@/app/_actions';
 import { Voting } from '@/app/_components/voting';
+import DEFAULTS from '@/utils/defaults';
 
 type SinglePostProps = {
   post: Post;
@@ -41,7 +42,11 @@ export async function SinglePost({ post }: SinglePostProps) {
         <div className="flex flex-col">
           <div className="flex gap-2 items-baseline justify-between">
             <a href={`#${post.id}`} className="text-xs text-zinc-500">
-              {post.createdAt.toDateString()}
+              {post.createdAt.toLocaleDateString(process.env.DATE_LOCALE ?? DEFAULTS.DATE_LOCALE, {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
             </a>
             {!reportingDisabled && (
               <form action={reportPost}>

--- a/app/_components/singlePost.tsx
+++ b/app/_components/singlePost.tsx
@@ -14,7 +14,7 @@ type SinglePostProps = {
 export async function SinglePost({ post }: SinglePostProps) {
   const fingerprint = cookies().get('fingerprint')?.value;
   if (!fingerprint) {
-    return <p>Something went wrong. Try refreshing the page.</p>;
+    return <p>Etwas ist schiefgelaufen. Bitte lade die Seite neu.</p>;
   }
 
   const votedPromise = prisma.vote.findFirst({

--- a/utils/defaults.ts
+++ b/utils/defaults.ts
@@ -4,6 +4,7 @@ const DEFAULTS = {
   MIN_CONTENT_LENGTH: 16,
   MIN_TITLE_LENGTH: 4,
   REPORTS_TO_HIDE_POST: 3,
+  DATE_LOCALE: 'de-DE',
 };
 
 export default DEFAULTS;


### PR DESCRIPTION
# Description

Use de-DE locale for date strings and translate English sentences to German

## Changes

1. Use de-DE locale for date strings
2. Translate English sentences to German

## References

Closes: #27 
